### PR TITLE
Bot with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,9 @@ COPY requirements.txt /usr/local/linkatos/requirements.txt
 WORKDIR /usr/local/linkatos
 
 RUN pip install -r requirements.txt
- # && rm -rf ~/.cache/pip /tmp/pip_build_root
 
 COPY linkatos.py /usr/local/linkatos/
 COPY linkatos /usr/local/linkatos/linkatos
 COPY tests /usr/local/linkatos/tests
 
-CMD ["linkatos.py"]
+CMD ["./linkatos.py"]

--- a/Makefile
+++ b/Makefile
@@ -3,27 +3,38 @@ id := linkatos
 
 image := $(id):$(VERSION)
 
+DOCKER_TASK = docker run --rm -it
 
 build:
 	docker build --tag $(image) .
 .PHONY: build
 
+install:
+	docker run -d --name $(id) \
+             --env SLACK_BOT_TOKEN=$(LINKATOS_SECRET) \
+             --env BOT_ID=$(LINKATOS_ID) \
+             $(image)
+.PHONY: install
 
-# typecheck: FILE_LIST = $(filter-out %/utils.py, $(wildcard listener/**/*.py))
-# typecheck: EXTRA_FLAGS = $(if $(VERBOSE), --stats)
-# typecheck:
-# 	@$(DOCKER_TASK) $(image) mypy --silent-imports $(EXTRA_FLAGS) $(FILE_LIST)
-# 	@$(call success,Finished static type checking)
-# .PHONY: typecheck
+clean:
+	docker rm -vf $(id)
+.PHONY: clean
+
+
+typecheck: FILE_LIST = $(filter-out %/utils.py, $(wildcard linkatos/*.py))
+typecheck: EXTRA_FLAGS = $(if $(VERBOSE), --stats)
+typecheck:
+	@$(DOCKER_TASK) $(image) mypy --silent-imports $(EXTRA_FLAGS) $(FILE_LIST)
+.PHONY: typecheck
 
 test:
-	@docker run --rm -t $(image) py.test -v tests
+	@$(DOCKER_TASK) $(image) py.test -v tests
 .PHONY: test
 
 shell:
-	@docker run --rm -it $(image) bash
+	@$(DOCKER_TASK) $(image) bash
 .PHONY: shell
 
 repl:
-	@docker run --rm -it $(image) python
+	@$(DOCKER_TASK) $(image) python
 .PHONY: repl

--- a/README.md
+++ b/README.md
@@ -10,10 +10,39 @@ This project intends to:
 
 ## Running the bot
 
-Currently the bot can only be run with:
-  ```sh
-  SLACK_BOT_TOKEN=apitoken BOT_ID=botid ./linkatos.py
-  ```
+To run the bot in isolation use the Dockerised version:
+
+First build the bot:
+
+```sh
+make build
+```
+
+Then
+
+```sh
+make install LINKATOS_SECRET=slacktoken LINKATOS_ID=botid
+```
+
+And, to stop the process and remove the Docker container:
+
+```sh
+make clean
+```
+
+
+If you run it outside Docker, first install the dependencies:
+
+```sh
+pip install -r requirements.txt
+```
+
+Then
+
+```sh
+SLACK_BOT_TOKEN=apitoken BOT_ID=botid ./linkatos.py
+```
+
 
 ## Tests
 


### PR DESCRIPTION
## Summary

Implements #6.

## Changes

* The README has an explanation of how to run the bot via Docker.
* There are two new make tasks: `install` to start the bot and `clean` to remove the bot container.

Note: I made the environment variables different from the ones expected by the bot to avoid future collisions with other slack bots.