### PR TITLE
Purge cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ that url.
 Use `@linkatos list` to ask linkatos to list all cached urls that have not yet
 been stored or ignored.
 
+Use `@linkatos purge <i>` to ask linkatos to remove the ith element from the
+cache as stated when running `@linkatos list`.
+
 
 ## Running the bot
 

--- a/linkatos/activities.py
+++ b/linkatos/activities.py
@@ -17,8 +17,8 @@ def is_not_from_bot(bot_id, user_id):
     return not bot_id == user_id
 
 
-def is_empty_list(url_cache_list):
-    return len(url_cache_list) == 0
+def is_empty_list(list):
+    return len(list) == 0
 
 
 def is_unfurled(event):

--- a/linkatos/activities.py
+++ b/linkatos/activities.py
@@ -16,6 +16,9 @@ def is_url(url_cache):
 def is_not_from_bot(bot_id, user_id):
     return not bot_id == user_id
 
+def is_empty_list(url_cache_list):
+    return len(url_cache_list) == 0
+
 
 def is_unfurled(event):
     return 'previous_message' in event
@@ -50,7 +53,8 @@ def event_consumer(url_cache_list, slack_client, bot_id,
                                              list_request['channel'],
                                              slack_client)
 
-                if purge_request['type'] == 'purge_request':
+                if purge_request['type'] == 'purge_request' and \
+                   not is_empty_list(url_cache_list):
                     remove_url_from(url_cache_list, purge_request['index'] - 1)
 
         if event['type'] == 'reaction_added' and len(url_cache_list) > 0:
@@ -58,6 +62,7 @@ def event_consumer(url_cache_list, slack_client, bot_id,
 
             if react.is_known(reaction['reaction']):
                 selected_url_cache = react.extract_url_cache(url_cache_list,
+                                                             reaction['to_id'])
                 react.handle(reaction['reaction'], selected_url_cache['url'],
                              fb_credentials, firebase)
 

--- a/linkatos/activities.py
+++ b/linkatos/activities.py
@@ -16,6 +16,7 @@ def is_url(url_cache):
 def is_not_from_bot(bot_id, user_id):
     return not bot_id == user_id
 
+
 def is_empty_list(url_cache_list):
     return len(url_cache_list) == 0
 
@@ -36,7 +37,7 @@ def event_consumer(url_cache_list, slack_client, bot_id,
         if is_unfurled(event):
             return url_cache_list
 
-        if event['type'] == 'message' and not 'username' in event:
+        if event['type'] == 'message' and 'username' not in event:
             new_url_cache = parser.parse_url_message(event)
 
             if is_url(new_url_cache) and is_not_from_bot(bot_id,

--- a/linkatos/activities.py
+++ b/linkatos/activities.py
@@ -43,11 +43,15 @@ def event_consumer(url_cache_list, slack_client, bot_id,
 
             if message.to_bot(event['text'], bot_id):
                 list_request = parser.parse_list_request(event)
+                purge_request = parser.parse_purge_request(event)
 
                 if 'type' in list_request and list_request['type'] == 'list_request':
                     printer.list_cached_urls(url_cache_list,
                                              list_request['channel'],
                                              slack_client)
+
+                if purge_request['type'] == 'purge_request':
+                    remove_url_from(url_cache_list, purge_request['index'] - 1)
 
         if event['type'] == 'reaction_added' and len(url_cache_list) > 0:
             reaction = parser.parse_reaction_added(event)

--- a/linkatos/activities.py
+++ b/linkatos/activities.py
@@ -55,14 +55,15 @@ def event_consumer(url_cache_list, slack_client, bot_id,
 
                 if purge_request['type'] == 'purge_request' and \
                    not is_empty_list(url_cache_list):
-                    remove_url_from(url_cache_list, purge_request['index'] - 1)
+                    react.extract_url_cache_by_index(url_cache_list,
+                                                     purge_request['index'] - 1)
 
         if event['type'] == 'reaction_added' and len(url_cache_list) > 0:
             reaction = parser.parse_reaction_added(event)
 
             if react.is_known(reaction['reaction']):
-                selected_url_cache = react.extract_url_cache(url_cache_list,
-                                                             reaction['to_id'])
+                selected_url_cache = react.extract_url_cache_by_id(url_cache_list,
+                                                                   reaction['to_id'])
                 react.handle(reaction['reaction'], selected_url_cache['url'],
                              fb_credentials, firebase)
 

--- a/linkatos/activities.py
+++ b/linkatos/activities.py
@@ -54,7 +54,6 @@ def event_consumer(url_cache_list, slack_client, bot_id,
 
             if react.is_known(reaction['reaction']):
                 selected_url_cache = react.extract_url_cache(url_cache_list,
-                                                             reaction['to_id'])
                 react.handle(reaction['reaction'], selected_url_cache['url'],
                              fb_credentials, firebase)
 

--- a/linkatos/activities.py
+++ b/linkatos/activities.py
@@ -49,12 +49,13 @@ def event_consumer(url_cache_list, slack_client, bot_id,
                 list_request = parser.parse_list_request(event)
                 purge_request = parser.parse_purge_request(event)
 
-                if 'type' in list_request and list_request['type'] == 'list_request':
+                if list_request is not None and list_request['type'] == 'list_request':
                     printer.list_cached_urls(url_cache_list,
                                              list_request['channel'],
                                              slack_client)
 
-                if purge_request['type'] == 'purge_request' and \
+                if purge_request is not None and \
+                   purge_request['type'] == 'purge_request' and \
                    not is_empty_list(url_cache_list):
                     react.extract_url_cache_by_index(url_cache_list,
                                                      purge_request['index'] - 1)

--- a/linkatos/activities.py
+++ b/linkatos/activities.py
@@ -57,6 +57,9 @@ def event_consumer(url_cache_list, slack_client, bot_id,
                    not is_empty_list(url_cache_list):
                     react.extract_url_cache_by_index(url_cache_list,
                                                      purge_request['index'] - 1)
+                    printer.list_cached_urls(url_cache_list,
+                                             purge_request['channel'],
+                                             slack_client)
 
         if event['type'] == 'reaction_added' and len(url_cache_list) > 0:
             reaction = parser.parse_reaction_added(event)

--- a/linkatos/activities.py
+++ b/linkatos/activities.py
@@ -44,6 +44,7 @@ def event_consumer(url_cache_list, slack_client, bot_id,
                                                          new_url_cache['user']):
                 url_cache_list.append(new_url_cache)
                 printer.ask_confirmation(new_url_cache, slack_client)
+                return url_cache_list
 
             if message.to_bot(event['text'], bot_id):
                 list_request = parser.parse_list_request(event)
@@ -53,6 +54,7 @@ def event_consumer(url_cache_list, slack_client, bot_id,
                     printer.list_cached_urls(url_cache_list,
                                              list_request['channel'],
                                              slack_client)
+                    return url_cache_list
 
                 if purge_request is not None and \
                    purge_request['type'] == 'purge_request' and \
@@ -62,6 +64,7 @@ def event_consumer(url_cache_list, slack_client, bot_id,
                     printer.list_cached_urls(url_cache_list,
                                              purge_request['channel'],
                                              slack_client)
+                    return url_cache_list
 
         if event['type'] == 'reaction_added' and len(url_cache_list) > 0:
             reaction = parser.parse_reaction_added(event)
@@ -71,5 +74,6 @@ def event_consumer(url_cache_list, slack_client, bot_id,
                                                                    reaction['to_id'])
                 react.handle(reaction['reaction'], selected_url_cache['url'],
                              fb_credentials, firebase)
+                return url_cache_list
 
     return url_cache_list

--- a/linkatos/message.py
+++ b/linkatos/message.py
@@ -1,14 +1,10 @@
 import re
 
-url_re = re.compile("(?:\s|^)<(https?://[\w./?+&+%$!#=\-_]+)>(?:\s|$)")
-purge_re = re.compile("(purge) (\d+)")
-list_re = re.compile("list")
-
 def extract_url(message):
     """
     Returns the first url in a message. If there aren't any returns None
     """
-    answer = url_re.search(message)
+    answer = re.search("(?:\s|^)<(https?://[\w./?+&+%$!#=\-_]+)>(?:\s|$)", message)
 
     if answer is not None:
         answer = answer.group(1).strip()
@@ -18,20 +14,19 @@ def extract_url(message):
 
 def to_bot(message, bot_id):
     bot_re = "^<@" + bot_id + '>'
-    to_bot_re = re.compile(bot_re)
-    bot_found = to_bot_re.search(message)
+    bot_found = re.search(bot_re, message)
 
     return bot_found is not None
 
 
 def is_list_request(message):
-    list_found = list_re.search(message)
+    list_found = re.search("list", message)
 
     return list_found is not None
 
 
 def purge_request(message):
-    index_found = purge_re.search(message)
+    index_found = re.search("(purge) (\d+)", message)
 
     if index_found is None:
         return None

--- a/linkatos/message.py
+++ b/linkatos/message.py
@@ -1,7 +1,8 @@
 import re
 
 url_re = re.compile("(?:\s|^)<(https?://[\w./?+&+%$!#=\-_]+)>(?:\s|$)")
-
+purge_re = re.compile("(purge) (\d+)")
+list_re = re.compile("list")
 
 def extract_url(message):
     """
@@ -24,14 +25,12 @@ def to_bot(message, bot_id):
 
 
 def is_list_request(message):
-    list_re = re.compile("list")
     list_found = list_re.search(message)
 
     return list_found is not None
 
 
 def purge_request(message):
-    purge_re = re.compile("(purge) (\d+)")
     index_found = purge_re.search(message)
 
     if index_found is None:

--- a/linkatos/message.py
+++ b/linkatos/message.py
@@ -28,3 +28,13 @@ def is_list_request(message):
     list_found = list_re.search(message)
 
     return list_found is not None
+
+
+def purge_request(message):
+    purge_re = re.compile("(purge) (\d+)")
+    index_found = purge_re.search(message)
+
+    if index_found is None:
+        return None
+
+    return int(index_found.group(2))

--- a/linkatos/parser.py
+++ b/linkatos/parser.py
@@ -50,7 +50,8 @@ def parse_purge_request(event):
 
     purge_request = {
         'index': index,
-        'type': 'purge_request'
+        'type': 'purge_request',
+        'channel': event['channel']
     }
 
     return purge_request

--- a/linkatos/parser.py
+++ b/linkatos/parser.py
@@ -41,3 +41,16 @@ def parse_list_request(event):
     }
 
     return list_request
+
+
+def parse_purge_request(event):
+    index = message.purge_request(event['text'])
+    if index is None:
+        return {'type': None}
+
+    purge_request = {
+        'index': index,
+        'type': 'purge_request'
+    }
+
+    return purge_request

--- a/linkatos/parser.py
+++ b/linkatos/parser.py
@@ -46,7 +46,7 @@ def parse_list_request(event):
 def parse_purge_request(event):
     index = message.purge_request(event['text'])
     if index is None:
-        return {'type': None}
+        return None
 
     purge_request = {
         'index': index,

--- a/linkatos/printer.py
+++ b/linkatos/printer.py
@@ -21,7 +21,7 @@ def compose_url_list(url_cache_list):
         return "The list is empty"
 
     intro = "The list of urls to be confirmed is: \n"
-    options = ["{} - {}".format(i, v['url']) for i, v in enumerate(url_cache_list)]
+    options = ["{} - {}".format(i + 1, v['url']) for i, v in enumerate(url_cache_list)]
 
     return intro + "\n".join(options)
 

--- a/linkatos/reaction.py
+++ b/linkatos/reaction.py
@@ -9,7 +9,7 @@ def is_known(reaction):
     return reaction in ['+1', '-1']
 
 
-def extract_url_cache(url_cache_list, reaction_to_id):
+def extract_url_cache_by_id(url_cache_list, reaction_to_id):
     for index in range(0, len(url_cache_list)):
         if url_cache_list[index]['id'] == reaction_to_id:
             url_cache = url_cache_list[index]
@@ -18,6 +18,15 @@ def extract_url_cache(url_cache_list, reaction_to_id):
 
     # if not found
     return None
+
+
+def extract_url_cache_by_index(url_cache_list, index):
+    if (index > len(url_cache_list) - 1) or (index < 0):
+        return None
+
+    url_cache = url_cache_list[index]
+    url_cache_list.pop(index)
+    return url_cache
 
 
 def handle(reaction, url, fb_credentials, firebase):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,84 +1,94 @@
 import pytest
-from linkatos import message
+from linkatos import message as mess
 
 
 # test url detection
 def test_basic_url_detection_of_https():
     expected = "https://example.org"
     text = "foo <https://example.org>"
-    assert message.extract_url(text) == expected
+    assert mess.extract_url(text) == expected
 
 
 def test_hash_in_url():
     expected = "https://foo.org#bar"
     text = "<https://foo.org#bar>"
-    assert message.extract_url(text) == expected
+    assert mess.extract_url(text) == expected
 
 
 def test_plus_in_url():
     expected = "http://foo.org/foo+bar"
     text = "<http://foo.org/foo+bar>"
-    assert message.extract_url(text) == expected
+    assert mess.extract_url(text) == expected
 
 
 def test_equal_in_url():
     expected = "http://example.org?q=foo"
     text = "<http://example.org?q=foo>"
-    assert message.extract_url(text) == expected
+    assert mess.extract_url(text) == expected
 
 
 def test_qmark_in_url():
     expected = "http://example.org?"
     text = "<http://example.org?>"
-    assert message.extract_url(text) == expected
+    assert mess.extract_url(text) == expected
 
 
 def test_and_in_url():
     expected = "http://example.org?foo=1&bar=2"
     text = "<http://example.org?foo=1&bar=2>"
-    assert message.extract_url(text) == expected
+    assert mess.extract_url(text) == expected
 
 
 def test_hyphen_in_url():
     expected = "https://this-is-a-test.org"
     text = "<https://this-is-a-test.org>"
-    assert message.extract_url(text) == expected
+    assert mess.extract_url(text) == expected
 
 
 def test_underscore_in_url():
     expected = "https://this_website.org"
     text = "<https://this_website.org>"
-    assert message.extract_url(text) == expected
+    assert mess.extract_url(text) == expected
 
 
 def test_detection_of_http_in_the_middle():
     expected = "http://example.com"
     text = "foo <http://example.com> bar"
-    assert message.extract_url(text) == expected
+    assert mess.extract_url(text) == expected
 
 
 def test_message_does_not_have_a_url():
     text = "foo <htts://no_url_example.org>"
-    assert message.extract_url(text) is None
+    assert mess.extract_url(text) is None
 
 
 def test_to_bot():
     text = '<@bot_id>'
     bot_id = 'bot_id'
-    assert message.to_bot(text, bot_id) is True
+    assert mess.to_bot(text, bot_id) is True
 
 
 def test_not_to_bot():
     text = '<@not_bot_id>'
     bot_id = 'bot_id'
-    assert message.to_bot(text, bot_id) is False
+    assert mess.to_bot(text, bot_id) is False
 
 
 def test_is_list():
     text = 'list'
-    assert message.is_list_request(text) is True
+    assert mess.is_list_request(text) is True
 
 
 def test_is_not_list():
     text = 'lOst'
-    assert message.is_list_request(text) is False
+    assert mess.is_list_request(text) is False
+
+
+def test_is_purge_request():
+    message = '<@linkatos> purge 2'
+    assert mess.purge_request(message) == 2
+
+
+def test_is_not_purge_request():
+    message = '<@linkatos> purSe 2'
+    assert mess.purge_request(message) is None

--- a/tests/test_reaction.py
+++ b/tests/test_reaction.py
@@ -49,6 +49,7 @@ def test_different_ids():
     id_two = 'e'
     assert react.extract_url_cache_by_id(url_cache_list, id_two) is None
 
+
 def test_found_index():
     url_cache_list = [
         {'id': 'a'},
@@ -56,9 +57,9 @@ def test_found_index():
         {'id': 'c'},
         {'id': 'd'},
     ]
-    index = 2
+    index = 2 - 1
     extracted = {'id': 'b'}
-    assert react.extract_url_cache_by_index(url_cache_list, index - 1) == extracted
+    assert react.extract_url_cache_by_index(url_cache_list, index) == extracted
 
 
 def test_out_of_bounds_index():

--- a/tests/test_reaction.py
+++ b/tests/test_reaction.py
@@ -36,7 +36,7 @@ def test_equal_ids():
     ]
     id_two = 'b'
     extracted = {'id': 'b'}
-    assert react.extract_url_cache(url_cache_list, id_two) == extracted
+    assert react.extract_url_cache_by_id(url_cache_list, id_two) == extracted
 
 
 def test_different_ids():
@@ -47,4 +47,26 @@ def test_different_ids():
         {'id': 'd'},
     ]
     id_two = 'e'
-    assert react.extract_url_cache(url_cache_list, id_two) is None
+    assert react.extract_url_cache_by_id(url_cache_list, id_two) is None
+
+def test_found_index():
+    url_cache_list = [
+        {'id': 'a'},
+        {'id': 'b'},
+        {'id': 'c'},
+        {'id': 'd'},
+    ]
+    index = 2
+    extracted = {'id': 'b'}
+    assert react.extract_url_cache_by_index(url_cache_list, index - 1) == extracted
+
+
+def test_out_of_bounds_index():
+    url_cache_list = [
+        {'id': 'a'},
+        {'id': 'b'},
+        {'id': 'c'},
+        {'id': 'd'},
+    ]
+    index = 5
+    assert react.extract_url_cache_by_index(url_cache_list, index - 1) is None


### PR DESCRIPTION
# Summary
This adds the ability of purging a specific element in the cache list. The element must be indicated using the list number.
After removing an element it automatically lists the cache so it's obvious what's still there.

It still doesn't allow a purge of the whole list at once but it's something I'd like to do in the future.

Note: I've changed the way the `purge_request` and `list_request` are dealt with when they're empty, i.e. None, because the previous method (`'type' in purge_request`) whas giving me an error.

# Usage
`@linkatos purge <list number>`

# Review
Please review structure and verify functionality.
