### PR TITLE
Add Linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ typecheck:
 	@$(DOCKER_TASK) $(image) mypy --silent-imports $(EXTRA_FLAGS) $(FILE_LIST)
 .PHONY: typecheck
 
+lint:
+	@$(DOCKER_TASK) $(image) pylint linkatos
+.PHONY: lint
+
 test:
 ifdef JUNIT
 	@$(DOCKER_TASK) $(image) ./test_runner.sh

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,10 @@ logs:
 typecheck: FILE_LIST = $(filter-out %/utils.py, $(wildcard linkatos/*.py))
 typecheck: EXTRA_FLAGS = $(if $(VERBOSE), --stats)
 typecheck:
-	@$(DOCKER_TASK) $(image) mypy --silent-imports $(EXTRA_FLAGS) $(FILE_LIST)
+	@$(DOCKER_TASK) $(image) \
+                  mypy --ignore-missing-imports \
+                       --follow-imports=skip \
+                       $(EXTRA_FLAGS) $(FILE_LIST)
 .PHONY: typecheck
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ shell:
                   --env FB_API_KEY=$(FB_API_KEY) \
                   --env FB_USER=$(FB_USER) \
                   --env FB_PASS=$(FB_PASS) \
-									$(image) bash
+                  $(image) bash
 .PHONY: shell
 
 repl:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ make build test
 ```
 
 
+## Lint
+
+To run the linter:
+
+```sh
+make build lint
+```
+
+
 ## Tools
 
 The initial choices of tools are:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mypy-lang==0.4.5
 pytest==3.0.3
 slackclient==1.0.2
 pyrebase==3.0.24
+pylint==1.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mypy-lang==0.4.5
+mypy==0.470
 pytest==3.0.3
 slackclient==1.0.2
 pyrebase==3.0.24


### PR DESCRIPTION
### Summary

This PR adds a linter (pylint) to help keeping the code close to PEP8.

### Review

Test `make lint` works (requires `make build` because it runs inside Docker, similar to `make test`).